### PR TITLE
JWT 기본 로그인/로그아웃 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,23 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!--   JWT    -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.3</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.3</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.3</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,19 +31,19 @@
 		<spring-cloud.version>2023.0.3</spring-cloud.version>
 	</properties>
 	<dependencies>
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter-data-jpa</artifactId>-->
-<!--		</dependency>-->
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter-data-redis</artifactId>-->
-<!--		</dependency>-->
-<!--		<dependency>-->
-<!--			<groupId>com.mysql</groupId>-->
-<!--			<artifactId>mysql-connector-j</artifactId>-->
-<!--			<scope>runtime</scope>-->
-<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,19 @@
 		<spring-cloud.version>2023.0.3</spring-cloud.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-data-jpa</artifactId>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-data-redis</artifactId>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>com.mysql</groupId>-->
+<!--			<artifactId>mysql-connector-j</artifactId>-->
+<!--			<scope>runtime</scope>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
@@ -62,12 +67,6 @@
 		<dependency>
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
 			<artifactId>jjwt-jackson</artifactId>
 			<version>0.12.3</version>
 		</dependency>
+		<!-- eureka -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/shop/nuribooks/auth/AuthApplication.java
+++ b/src/main/java/shop/nuribooks/auth/AuthApplication.java
@@ -3,13 +3,13 @@ package shop.nuribooks.auth;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class AuthApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(AuthApplication.class, args);
 	}
-
 }

--- a/src/main/java/shop/nuribooks/auth/AuthApplication.java
+++ b/src/main/java/shop/nuribooks/auth/AuthApplication.java
@@ -2,8 +2,10 @@ package shop.nuribooks.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class AuthApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/shop/nuribooks/auth/common/config/CorsMvcConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/CorsMvcConfig.java
@@ -1,0 +1,19 @@
+package shop.nuribooks.auth.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:3000")
+			.allowCredentials(true)
+			.allowedHeaders("*")
+			.allowedMethods("*")
+			.exposedHeaders("Authorization")
+			.maxAge(60 * 60L);
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import shop.nuribooks.auth.common.filter.CustomLoginFilter;
 import shop.nuribooks.auth.common.filter.JwtFilter;
 import shop.nuribooks.auth.common.util.JwtUtils;
+import shop.nuribooks.auth.repository.RefreshTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -46,7 +47,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager, JwtUtils jwtUtils) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager, JwtUtils jwtUtils, RefreshTokenRepository refreshTokenRepository) throws Exception {
 		http
 			.exceptionHandling(exception -> exception
 				.authenticationEntryPoint(new AuthenticationEntryPoint() {
@@ -96,7 +97,7 @@ public class SecurityConfig {
 			.addFilterBefore(new JwtFilter(jwtUtils), CustomLoginFilter.class);
 
 		http
-			.addFilterAt(new CustomLoginFilter(authenticationManager, jwtUtils), UsernamePasswordAuthenticationFilter.class);
+			.addFilterAt(new CustomLoginFilter(authenticationManager, jwtUtils, refreshTokenRepository), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/", "/login").permitAll()
+				.requestMatchers("/", "/login", "/reissue").permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package shop.nuribooks.auth.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,17 +14,26 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import shop.nuribooks.auth.common.filter.CustomLoginFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws
+		Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
 	@Bean
 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
 
 		http
 			.csrf(AbstractHttpConfigurer::disable);
@@ -41,6 +52,9 @@ public class SecurityConfig {
 		http
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		http
+			.addFilterAt(new CustomLoginFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -110,14 +110,14 @@ public class SecurityConfig {
 	@Bean
 	public UserDetailsService userDetailsService() {
 		UserDetails admin = User.builder()
-			.username("admin")
-			.password(bCryptPasswordEncoder().encode("123"))
+			.username("admin12345")
+			.password(bCryptPasswordEncoder().encode("12345678"))
 			.roles("ADMIN")
 			.build();
 
 		UserDetails user = User.builder()
-			.username("user")
-			.password(bCryptPasswordEncoder().encode("123"))
+			.username("user12345")
+			.password(bCryptPasswordEncoder().encode("12345678"))
 			.roles("USER")
 			.build();
 

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import shop.nuribooks.auth.common.filter.CustomLoginFilter;
+import shop.nuribooks.auth.common.util.JwtUtils;
 
 @Configuration
 @EnableWebSecurity
@@ -33,7 +34,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager, JwtUtils jwtUtils) throws Exception {
 
 		http
 			.csrf(AbstractHttpConfigurer::disable);
@@ -54,7 +55,7 @@ public class SecurityConfig {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
 		http
-			.addFilterAt(new CustomLoginFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class);
+			.addFilterAt(new CustomLoginFilter(authenticationManager, jwtUtils), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/", "/api/auth/login", "/api/auth/reissue").permitAll()
+				.requestMatchers("/", "/api/auth/login", "/api/auth/reissue", "/auth/login").permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package shop.nuribooks.auth.common.config;
 
+import java.io.IOException;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -8,15 +10,21 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import shop.nuribooks.auth.common.filter.CustomLoginFilter;
+import shop.nuribooks.auth.common.filter.JwtFilter;
 import shop.nuribooks.auth.common.util.JwtUtils;
 
 @Configuration
@@ -35,6 +43,16 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager, JwtUtils jwtUtils) throws Exception {
+		http
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(new AuthenticationEntryPoint() {
+					@Override
+					public void commence(HttpServletRequest request, HttpServletResponse response,
+						AuthenticationException authException) throws IOException, ServletException {
+						response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+					}
+				}));
+
 
 		http
 			.csrf(AbstractHttpConfigurer::disable);
@@ -48,11 +66,15 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/login").permitAll()
+				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 
 		http
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		http
+			.addFilterBefore(new JwtFilter(jwtUtils), CustomLoginFilter.class);
 
 		http
 			.addFilterAt(new CustomLoginFilter(authenticationManager, jwtUtils), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -87,8 +87,7 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/", "/api/auth/login", "/api/auth/reissue", "/auth/login").permitAll()
-				.requestMatchers("/admin").hasRole("ADMIN")
+				.requestMatchers("/api/auth/login", "/api/auth/reissue").permitAll()
 				.anyRequest().authenticated());
 
 		http
@@ -105,23 +104,6 @@ public class SecurityConfig {
 			.addFilterAt(new CustomLoginFilter(authenticationManager, jwtUtils, refreshTokenRepository), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
-	}
-
-	@Bean
-	public UserDetailsService userDetailsService() {
-		UserDetails admin = User.builder()
-			.username("admin12345")
-			.password(bCryptPasswordEncoder().encode("12345678"))
-			.roles("ADMIN")
-			.build();
-
-		UserDetails user = User.builder()
-			.username("user12345")
-			.password(bCryptPasswordEncoder().encode("12345678"))
-			.roles("USER")
-			.build();
-
-		return new InMemoryUserDetailsManager(admin, user);
 	}
 
 	@Bean

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -28,6 +29,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import shop.nuribooks.auth.common.filter.CustomLoginFilter;
+import shop.nuribooks.auth.common.filter.CustomLogoutFilter;
 import shop.nuribooks.auth.common.filter.JwtFilter;
 import shop.nuribooks.auth.common.util.JwtUtils;
 import shop.nuribooks.auth.repository.RefreshTokenRepository;
@@ -85,13 +87,16 @@ public class SecurityConfig {
 
 		http
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/", "/login", "/reissue").permitAll()
+				.requestMatchers("/", "/api/auth/login", "/api/auth/reissue").permitAll()
 				.requestMatchers("/admin").hasRole("ADMIN")
 				.anyRequest().authenticated());
 
 		http
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		http
+			.addFilterBefore(new CustomLogoutFilter(jwtUtils, refreshTokenRepository), LogoutFilter.class);
 
 		http
 			.addFilterBefore(new JwtFilter(jwtUtils), CustomLoginFilter.class);

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package shop.nuribooks.auth.common.config;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.AuthenticationException;
@@ -19,6 +21,8 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,6 +57,21 @@ public class SecurityConfig {
 					}
 				}));
 
+		http
+			.cors(cors -> cors
+				.configurationSource(new CorsConfigurationSource() {
+					@Override
+					public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+						CorsConfiguration configuration = new CorsConfiguration();
+						configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));	// client가 접근하는 URL
+						configuration.setAllowedMethods(Collections.singletonList("*"));
+						configuration.setAllowCredentials(true);	// cookie 포함
+						configuration.setAllowedHeaders(Collections.singletonList("*"));
+						configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+						configuration.setMaxAge(60 * 60L);
+						return configuration;
+					}
+				}));
 
 		http
 			.csrf(AbstractHttpConfigurer::disable);
@@ -97,5 +116,10 @@ public class SecurityConfig {
 			.build();
 
 		return new InMemoryUserDetailsManager(admin, user);
+	}
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return web -> web.ignoring().requestMatchers("/favicon.ico", "/static/**");
 	}
 }

--- a/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
+++ b/src/main/java/shop/nuribooks/auth/common/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package shop.nuribooks.auth.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+	@Bean
+	public BCryptPasswordEncoder bCryptPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+		http
+			.csrf(AbstractHttpConfigurer::disable);
+
+		http.
+			formLogin(AbstractHttpConfigurer::disable);
+
+		http
+			.httpBasic(AbstractHttpConfigurer::disable);
+
+		http
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/", "/login").permitAll()
+				.anyRequest().authenticated());
+
+		http
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		return http.build();
+	}
+
+	@Bean
+	public UserDetailsService userDetailsService() {
+		UserDetails admin = User.builder()
+			.username("admin")
+			.password(bCryptPasswordEncoder().encode("123"))
+			.roles("ADMIN")
+			.build();
+
+		UserDetails user = User.builder()
+			.username("user")
+			.password(bCryptPasswordEncoder().encode("123"))
+			.roles("USER")
+			.build();
+
+		return new InMemoryUserDetailsManager(admin, user);
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/feign/MemberFeignClient.java
+++ b/src/main/java/shop/nuribooks/auth/common/feign/MemberFeignClient.java
@@ -1,0 +1,14 @@
+package shop.nuribooks.auth.common.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import shop.nuribooks.auth.dto.MemberResponse;
+
+@FeignClient(name = "memberFeignClient", url = "http://localhost:8083/api/member")
+public interface MemberFeignClient {
+	@GetMapping("/{username}")
+	ResponseEntity<MemberResponse> findByUsername(@PathVariable String username);
+}

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import jakarta.servlet.FilterChain;
@@ -14,13 +15,17 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.auth.common.util.CookieUtils;
+import shop.nuribooks.auth.common.util.JwtUtils;
 
 @Slf4j
 public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 	private final AuthenticationManager authenticationManager;
+	private final JwtUtils jwtUtils;
 
-	public CustomLoginFilter(AuthenticationManager authenticationManager) {
+	public CustomLoginFilter(AuthenticationManager authenticationManager, JwtUtils jwtUtils) {
 		this.authenticationManager = authenticationManager;
+		this.jwtUtils = jwtUtils;
 	}
 
 	@Override
@@ -35,8 +40,18 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
-		Authentication authResult) throws IOException, ServletException {
+		Authentication authentication) throws IOException, ServletException {
 		log.info("로그인 성공");
+
+		UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+		String username = userDetails.getUsername();
+		String role = userDetails.getAuthorities().iterator().next().getAuthority();
+
+		String accessToken = jwtUtils.createJwt("access", username, role, 60 * 60 * 200L);
+		String refreshToken = jwtUtils.createJwt("refresh", username, role, 60 * 60 * 1000L * 24);
+
+		response.addHeader("Authorization", "Bearer " + accessToken);
+		response.addCookie(CookieUtils.createCookie("refresh", refreshToken));
 		response.setStatus(HttpStatus.OK.value());
 	}
 

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -47,11 +47,11 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		String username = userDetails.getUsername();
 		String role = userDetails.getAuthorities().iterator().next().getAuthority();
 
-		String accessToken = jwtUtils.createJwt("access", username, role, 60 * 60 * 1000000L);
-		String refreshToken = jwtUtils.createJwt("refresh", username, role, 60 * 60 * 1000L * 24);
+		String accessToken = jwtUtils.createJwt("Access", username, role, 60 * 60 * 200L);
+		String refreshToken = jwtUtils.createJwt("Refresh", username, role, 60 * 60 * 1000L * 24);
 
-		response.addHeader("Authorization", "Bearer " + accessToken);
-		response.addCookie(CookieUtils.createCookie("refresh", refreshToken));
+		response.setHeader("Authorization", "Bearer " + accessToken);
+		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken));
 		response.setStatus(HttpStatus.OK.value());
 	}
 

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -46,8 +46,6 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		// String username = obtainUsername(request);
 		// String password = obtainPassword(request);
 
-
-
 		// application/json 요청 기반
 		ObjectMapper objectMapper = new ObjectMapper();
 		LoginRequest loginRequest = null;
@@ -58,8 +56,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 			return null;
 		}
 
-		String username = loginRequest.getUsername();
-		String password = loginRequest.getPassword();
+		String username = loginRequest.username();
+		String password = loginRequest.password();
 
 		log.info("로그인 시도 : {}/{}", username, password);
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password, null);

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -47,7 +47,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		String username = userDetails.getUsername();
 		String role = userDetails.getAuthorities().iterator().next().getAuthority();
 
-		String accessToken = jwtUtils.createJwt("access", username, role, 60 * 60 * 200L);
+		String accessToken = jwtUtils.createJwt("access", username, role, 60 * 60 * 1000000L);
 		String refreshToken = jwtUtils.createJwt("refresh", username, role, 60 * 60 * 1000L * 24);
 
 		response.addHeader("Authorization", "Bearer " + accessToken);

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -31,6 +31,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		this.authenticationManager = authenticationManager;
 		this.jwtUtils = jwtUtils;
 		this.refreshTokenRepository = refreshTokenRepository;
+		setFilterProcessesUrl("/api/auth/login");
 	}
 
 	@Override
@@ -55,7 +56,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		String refreshToken = jwtUtils.createJwt("Refresh", username, role, 60 * 60 * 1000L * 24);
 
 		response.setHeader("Authorization", "Bearer " + accessToken);
-		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken));
+		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken, 60 * 60));
 		addRefreshToken(username, accessToken, refreshToken, 60 * 60 * 1000L * 24);
 		log.info("로그인 성공! Refresh Token을 저장하였습니다.");
 		response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -83,19 +84,20 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
 		// TODO: login 요청 성공 후
 		// JSON 응답을 반환하도록 변경
-		response.setContentType("application/json");
-		response.getWriter().write("{\"message\":\"Login successful\"}");
-		response.setStatus(HttpStatus.OK.value());
+		ResponseEntity<String> responseEntity = ResponseEntity.ok("{\"message\":\"Login successful\"}");
+		response.setStatus(responseEntity.getStatusCodeValue());
+		response.getWriter().write(responseEntity.getBody());
 	}
 
 	@Override
 	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException failed) throws IOException, ServletException {
 		log.info("로그인 실패");
-		// JSON 응답을 반환하도록 변경
-		response.setContentType("application/json");
-		response.getWriter().write("{\"message\":\"Login failed\"}");
-		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		// ResponseEntity를 사용하여 JSON 응답 생성
+		ResponseEntity<String> responseEntity = ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+			.body("{\"message\":\"Login failed\"}");
+		response.setStatus(responseEntity.getStatusCodeValue());
+		response.getWriter().write(responseEntity.getBody());
 	}
 
 	private void addRefreshToken(String username, String accessToken, String refreshToken, Long expiredMs) {

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -11,13 +11,17 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import shop.nuribooks.auth.common.util.CookieUtils;
 import shop.nuribooks.auth.common.util.JwtUtils;
+import shop.nuribooks.auth.dto.LoginRequest;
 import shop.nuribooks.auth.entity.RefreshToken;
 import shop.nuribooks.auth.repository.RefreshTokenRepository;
 
@@ -37,8 +41,22 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 	@Override
 	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
 		AuthenticationException {
-		String username = obtainUsername(request);
-		String password = obtainPassword(request);
+		// form 요청 기반
+		// String username = obtainUsername(request);
+		// String password = obtainPassword(request);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		LoginRequest loginRequest = null;
+		try {
+			 loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+		} catch (Exception e) {
+			log.info("로그인 요청 정보를 가져오는데 실패하였습니다.");
+			return null;
+		}
+
+		String username = loginRequest.getUsername();
+		String password = loginRequest.getPassword();
+
 		log.info("로그인 시도 : {}/{}", username, password);
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password, null);
 		return authenticationManager.authenticate(token);

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -45,6 +45,9 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		// String username = obtainUsername(request);
 		// String password = obtainPassword(request);
 
+
+
+		// application/json 요청 기반
 		ObjectMapper objectMapper = new ObjectMapper();
 		LoginRequest loginRequest = null;
 		try {
@@ -77,6 +80,11 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken, 60 * 60));
 		addRefreshToken(username, accessToken, refreshToken, 60 * 60 * 1000L * 24);
 		log.info("로그인 성공! Refresh Token을 저장하였습니다.");
+
+		// TODO: login 요청 성공 후
+		// JSON 응답을 반환하도록 변경
+		response.setContentType("application/json");
+		response.getWriter().write("{\"message\":\"Login successful\"}");
 		response.setStatus(HttpStatus.OK.value());
 	}
 
@@ -84,7 +92,10 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException failed) throws IOException, ServletException {
 		log.info("로그인 실패");
-		response.setStatus(HttpStatus.BAD_REQUEST.value());
+		// JSON 응답을 반환하도록 변경
+		response.setContentType("application/json");
+		response.getWriter().write("{\"message\":\"Login failed\"}");
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
 	}
 
 	private void addRefreshToken(String username, String accessToken, String refreshToken, Long expiredMs) {

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +23,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import shop.nuribooks.auth.common.util.CookieUtils;
 import shop.nuribooks.auth.common.util.JwtUtils;
+import shop.nuribooks.auth.dto.CustomUserDetails;
 import shop.nuribooks.auth.dto.LoginRequest;
 import shop.nuribooks.auth.entity.RefreshToken;
 import shop.nuribooks.auth.repository.RefreshTokenRepository;
@@ -42,10 +44,6 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 	@Override
 	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
 		AuthenticationException {
-		// form 요청 기반
-		// String username = obtainUsername(request);
-		// String password = obtainPassword(request);
-
 		// application/json 요청 기반
 		ObjectMapper objectMapper = new ObjectMapper();
 		LoginRequest loginRequest = null;
@@ -58,17 +56,16 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
 		String username = loginRequest.username();
 		String password = loginRequest.password();
-
 		log.info("로그인 시도 : {}/{}", username, password);
-		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password, null);
+
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password);
 		return authenticationManager.authenticate(token);
 	}
 
 	@Override
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
 		Authentication authentication) throws IOException, ServletException {
-
-		UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+		CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 		String username = userDetails.getUsername();
 		String role = userDetails.getAuthorities().iterator().next().getAuthority();
 

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -1,0 +1,49 @@
+package shop.nuribooks.auth.common.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+	private final AuthenticationManager authenticationManager;
+
+	public CustomLoginFilter(AuthenticationManager authenticationManager) {
+		this.authenticationManager = authenticationManager;
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
+		AuthenticationException {
+		String username = obtainUsername(request);
+		String password = obtainPassword(request);
+		log.info("로그인 시도 : {}/{}", username, password);
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password, null);
+		return authenticationManager.authenticate(token);
+	}
+
+	@Override
+	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+		Authentication authResult) throws IOException, ServletException {
+		log.info("로그인 성공");
+		response.setStatus(HttpStatus.OK.value());
+	}
+
+	@Override
+	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException failed) throws IOException, ServletException {
+		log.info("로그인 실패");
+		response.setStatus(HttpStatus.BAD_REQUEST.value());
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLogoutFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLogoutFilter.java
@@ -1,0 +1,72 @@
+package shop.nuribooks.auth.common.filter;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.GenericFilterBean;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.auth.common.util.CookieUtils;
+import shop.nuribooks.auth.common.util.JwtUtils;
+import shop.nuribooks.auth.repository.RefreshTokenRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+	private final JwtUtils jwtUtils;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws
+		IOException,
+		ServletException {
+		doFilter((HttpServletRequest)servletRequest, (HttpServletResponse)servletResponse, filterChain);
+	}
+
+	private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
+		ServletException,
+		IOException {
+		if (!request.getRequestURI().matches("^/api/auth/logout$") || !request.getMethod().equals("POST")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String refreshToken = CookieUtils.getValue(request, "Refresh");
+		if (refreshToken == null || refreshToken.isBlank()) {
+			log.info("Refresh Token 없는 유저의 로그아웃 요청입니다.");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		if (!jwtUtils.getTokenType(refreshToken).equals("Refresh")) {
+			log.info("Refresh Token이 아닙니다.");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		if (jwtUtils.isExpired(refreshToken)) {
+			log.info("이미 완료된 Refresh Token입니다.");
+			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		if (!refreshTokenRepository.existsByRefreshToken(refreshToken)) {
+			log.info("요청한 Refresh Token은 존재하지 않습니다.");
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
+
+		refreshTokenRepository.deleteByRefreshToken(refreshToken);
+
+		// TODO: Access Token의 생명주기가 짧아 front에서만 쿠키를 삭제해도 괜찮을 것 같은데, 아니면 Blacklist 도입할까?
+		log.info("로그아웃 성공!");
+		response.addCookie(CookieUtils.createCookie("Refresh", null, 0));
+		response.setStatus(HttpServletResponse.SC_OK);
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/filter/JwtFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/JwtFilter.java
@@ -1,0 +1,61 @@
+package shop.nuribooks.auth.common.filter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.auth.common.util.JwtUtils;
+
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+	private final JwtUtils jwtUtils;
+
+	public JwtFilter(JwtUtils jwtUtils) {
+		this.jwtUtils = jwtUtils;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		log.info("JwtFilter를 통과합니다.");
+		// TODO: login 요청인 경우 토큰 유무에 관계 없이 바로 다음 필터로 보내는건 어떨까?
+
+		String accessToken = request.getHeader("Authorization");
+		// Access 토큰이 없는 경우
+		if (accessToken == null || accessToken.isBlank() || !accessToken.startsWith("Bearer ")) {
+			log.info("Access Token이 존재하지않습니다.");
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+
+		String validAccessToken = accessToken.split(" ")[1];
+		// Access 토큰이 만료된 경우
+		if (jwtUtils.isExpired(validAccessToken)) {
+			log.info("Access Token이 만료되었습니다. 재발급받으십시오.");
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// Access 토큰이 유효한 경우 => 로그인 처리
+		String username = jwtUtils.getUsername(validAccessToken);
+		String role = jwtUtils.getRole(validAccessToken);
+		UserDetails userDetails = new User(username, "p@ssW0rd", Collections.singleton(new SimpleGrantedAuthority(role)));
+		Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		log.info("Access Token이 유효하여 자동 로그인 처리되었습니다. : {}/{}", userDetails.getUsername(), userDetails.getPassword());
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/filter/JwtFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/JwtFilter.java
@@ -40,7 +40,6 @@ public class JwtFilter extends OncePerRequestFilter {
 			return;
 		}
 
-
 		String validAccessToken = accessToken.split(" ")[1];
 		// Access 토큰이 만료된 경우
 		if (jwtUtils.isExpired(validAccessToken)) {

--- a/src/main/java/shop/nuribooks/auth/common/util/CookieUtils.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/CookieUtils.java
@@ -1,0 +1,27 @@
+package shop.nuribooks.auth.common.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtils {
+	public static Cookie createCookie(String key, String value) {
+		Cookie cookie = new Cookie(key, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(60 * 60);
+		// cookie.setSecure(false);
+		return cookie;
+	}
+
+	public static String getValue(HttpServletRequest request, String key) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(key)) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/util/CookieUtils.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/CookieUtils.java
@@ -4,11 +4,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class CookieUtils {
-	public static Cookie createCookie(String key, String value) {
+	public static Cookie createCookie(String key, String value, int maxAge) {
 		Cookie cookie = new Cookie(key, value);
 		cookie.setPath("/");
 		cookie.setHttpOnly(true);
-		cookie.setMaxAge(60 * 60);
+		cookie.setMaxAge(maxAge);
 		// cookie.setSecure(false);
 		return cookie;
 	}

--- a/src/main/java/shop/nuribooks/auth/common/util/JwtProperties.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/JwtProperties.java
@@ -1,0 +1,16 @@
+package shop.nuribooks.auth.common.util;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+	private String issuer;
+	private String secretKey;
+}

--- a/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
@@ -1,0 +1,72 @@
+package shop.nuribooks.auth.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtUtils {
+	private final SecretKey secretKey;
+	private final JwtProperties jwtProperties;
+
+	public JwtUtils(JwtProperties jwtProperties) {
+		this.jwtProperties = jwtProperties;
+		this.secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+	}
+
+	public String getTokenType(String token) {
+		try {
+			return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+		} catch (Exception ex) {
+			log.info("TokenType을 가져오는데 실패하였습니다.");
+		}
+		return null;
+	}
+
+	public String getUsername(String token) {
+		try {
+			return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+		} catch (Exception ex) {
+			log.info("Username을 가져오는데 실패하였습니다.");
+		}
+		return null;
+	}
+
+	public String getRole(String token) {
+		try {
+			return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+		} catch (Exception ex) {
+			log.info("Role을 가져오는데 실패하였습니다.");
+		}
+		return null;
+	}
+
+	public Boolean isExpired(String token) {
+		try {
+			return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+		} catch (Exception ex) {
+			log.info("만료기한을 가져오는데 실패하였습니다.");
+		}
+		return null;
+	}
+
+	public String createJwt(String tokenType, String username, String role, Long expiredMs) {
+		return Jwts.builder()
+			.claim("tokenType", tokenType)
+			.claim("username", username)
+			.claim("role", role)
+			.issuedAt(new Date())
+			.expiration(new Date(System.currentTimeMillis() + expiredMs))
+			.claim("issuer", jwtProperties.getIssuer())
+			.signWith(secretKey)
+			.compact();
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
@@ -55,7 +55,7 @@ public class JwtUtils {
 		} catch (Exception ex) {
 			log.info("만료기한을 가져오는데 실패하였습니다.");
 		}
-		return null;
+		return true;
 	}
 
 	public String createJwt(String tokenType, String username, String role, Long expiredMs) {
@@ -63,7 +63,7 @@ public class JwtUtils {
 			.claim("tokenType", tokenType)
 			.claim("username", username)
 			.claim("role", role)
-			.issuedAt(new Date())
+			.issuedAt(new Date(System.currentTimeMillis()))
 			.expiration(new Date(System.currentTimeMillis() + expiredMs))
 			.claim("issuer", jwtProperties.getIssuer())
 			.signWith(secretKey)

--- a/src/main/java/shop/nuribooks/auth/controller/AuthController.java
+++ b/src/main/java/shop/nuribooks/auth/controller/AuthController.java
@@ -16,30 +16,7 @@ import shop.nuribooks.auth.service.AuthService;
 @RestController
 public class AuthController {
 	private final AuthService authService;
-
-	@GetMapping("/")
-	@ResponseBody
-	public String home() {
-		return "index page";
-	}
-
-	@GetMapping("/my")
-	@ResponseBody
-	public String my() {
-		return "my page";
-	}
-
-	@GetMapping("/admin")
-	@ResponseBody
-	public String admin() {
-		return "admin page";
-	}
-
-	@GetMapping("/auth/login")
-	public String login() {
-		return "login page";
-	}
-
+	
 	@PostMapping("/reissue")
 	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
 		return authService.reissue(request, response);

--- a/src/main/java/shop/nuribooks/auth/controller/AuthController.java
+++ b/src/main/java/shop/nuribooks/auth/controller/AuthController.java
@@ -1,10 +1,20 @@
 package shop.nuribooks.auth.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import shop.nuribooks.auth.service.AuthService;
+
+@RequiredArgsConstructor
 @RestController
 public class AuthController {
+	private final AuthService authService;
+
 	@GetMapping("/")
 	public String home() {
 		return "Hello Index";
@@ -18,5 +28,10 @@ public class AuthController {
 	@GetMapping("/admin")
 	public String admin() {
 		return "Hello ADMIN";
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+		return authService.reissue(request, response);
 	}
 }

--- a/src/main/java/shop/nuribooks/auth/controller/AuthController.java
+++ b/src/main/java/shop/nuribooks/auth/controller/AuthController.java
@@ -1,0 +1,22 @@
+package shop.nuribooks.auth.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+	@GetMapping("/")
+	public String home() {
+		return "Hello Index";
+	}
+
+	@GetMapping("/my")
+	public String my() {
+		return "my!";
+	}
+
+	@GetMapping("/admin")
+	public String admin() {
+		return "Hello ADMIN";
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/controller/AuthController.java
+++ b/src/main/java/shop/nuribooks/auth/controller/AuthController.java
@@ -14,7 +14,6 @@ import shop.nuribooks.auth.service.AuthService;
 
 @RequiredArgsConstructor
 @RestController
-// @Controller
 public class AuthController {
 	private final AuthService authService;
 

--- a/src/main/java/shop/nuribooks/auth/controller/AuthController.java
+++ b/src/main/java/shop/nuribooks/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package shop.nuribooks.auth.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,22 +14,31 @@ import shop.nuribooks.auth.service.AuthService;
 
 @RequiredArgsConstructor
 @RestController
+// @Controller
 public class AuthController {
 	private final AuthService authService;
 
 	@GetMapping("/")
+	@ResponseBody
 	public String home() {
-		return "Hello Index";
+		return "index page";
 	}
 
 	@GetMapping("/my")
+	@ResponseBody
 	public String my() {
-		return "my!";
+		return "my page";
 	}
 
 	@GetMapping("/admin")
+	@ResponseBody
 	public String admin() {
-		return "Hello ADMIN";
+		return "admin page";
+	}
+
+	@GetMapping("/auth/login")
+	public String login() {
+		return "login page";
 	}
 
 	@PostMapping("/reissue")

--- a/src/main/java/shop/nuribooks/auth/dto/CustomUserDetails.java
+++ b/src/main/java/shop/nuribooks/auth/dto/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package shop.nuribooks.auth.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+	private final MemberResponse user;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new GrantedAuthority() {
+			@Override
+			public String getAuthority() {
+				return user.role();
+			}
+		});
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.password();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.username();
+	}
+
+	// TODO : 회원 DB에서 해당 계정이 유효한지, 만료되었는지 등 상태 가져와 수정 예정
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/dto/LoginRequest.java
+++ b/src/main/java/shop/nuribooks/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package shop.nuribooks.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoginRequest {
+	private String username;
+	private String password;
+}

--- a/src/main/java/shop/nuribooks/auth/dto/LoginRequest.java
+++ b/src/main/java/shop/nuribooks/auth/dto/LoginRequest.java
@@ -1,13 +1,4 @@
 package shop.nuribooks.auth.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@NoArgsConstructor
-public class LoginRequest {
-	private String username;
-	private String password;
+public record LoginRequest(String username, String password) {
 }

--- a/src/main/java/shop/nuribooks/auth/dto/MemberResponse.java
+++ b/src/main/java/shop/nuribooks/auth/dto/MemberResponse.java
@@ -1,0 +1,4 @@
+package shop.nuribooks.auth.dto;
+
+public record MemberResponse(String username, String password, String role) {
+}

--- a/src/main/java/shop/nuribooks/auth/entity/RefreshToken.java
+++ b/src/main/java/shop/nuribooks/auth/entity/RefreshToken.java
@@ -1,0 +1,4 @@
+package shop.nuribooks.auth.entity;
+
+public class RefreshToken {
+}

--- a/src/main/java/shop/nuribooks/auth/entity/RefreshToken.java
+++ b/src/main/java/shop/nuribooks/auth/entity/RefreshToken.java
@@ -1,4 +1,23 @@
 package shop.nuribooks.auth.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Table(name = "refresh_token")
+@Entity
 public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String username;
+	private String accessToken;
+	private String refreshToken;
+	private String expiration;
 }

--- a/src/main/java/shop/nuribooks/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/shop/nuribooks/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,4 @@
+package shop.nuribooks.auth.repository;
+
+public class RefreshToken {
+}

--- a/src/main/java/shop/nuribooks/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/shop/nuribooks/auth/repository/RefreshTokenRepository.java
@@ -1,4 +1,13 @@
 package shop.nuribooks.auth.repository;
 
-public class RefreshToken {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import shop.nuribooks.auth.entity.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	boolean existsByRefreshToken(String refreshToken);
+
+	@Transactional
+	void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/shop/nuribooks/auth/service/AuthService.java
+++ b/src/main/java/shop/nuribooks/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
 	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
 		String refreshToken = CookieUtils.getValue(request, "Refresh");
 
-		if (refreshToken == null) {
+		if (refreshToken == null || refreshToken.isBlank()) {
 			log.info("Refresh Token is NULL");
 			return new ResponseEntity<>("Refresh Token is NULL", HttpStatus.BAD_REQUEST);
 		}
@@ -45,7 +45,7 @@ public class AuthService {
 		String newAccessToken = jwtUtils.createJwt("Access", username, role, 60 * 60 * 200L);
 		String newRefreshToken = jwtUtils.createJwt("Refresh", username, role, 60 * 60 * 1000L * 24);
 		response.setHeader("Authorization", newAccessToken);
-		response.addCookie(CookieUtils.createCookie("Refresh", newRefreshToken));
+		response.addCookie(CookieUtils.createCookie("Refresh", newRefreshToken, 60 * 60));
 		refreshTokenRepository.deleteByRefreshToken(refreshToken);
 		addRefreshToken(username, newAccessToken, newRefreshToken, 60 * 60 * 1000L * 24);
 		log.info("Reissue Completed : Refresh Rotating, Saving New Refresh");

--- a/src/main/java/shop/nuribooks/auth/service/AuthService.java
+++ b/src/main/java/shop/nuribooks/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package shop.nuribooks.auth.service;
 
+import java.util.Date;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -10,11 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import shop.nuribooks.auth.common.util.CookieUtils;
 import shop.nuribooks.auth.common.util.JwtUtils;
+import shop.nuribooks.auth.entity.RefreshToken;
+import shop.nuribooks.auth.repository.RefreshTokenRepository;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class AuthService {
+	private final RefreshTokenRepository refreshTokenRepository;
 	private final JwtUtils jwtUtils;
 
 	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
@@ -30,11 +35,30 @@ public class AuthService {
 			return new ResponseEntity<>("Refresh Token is Expired", HttpStatus.BAD_REQUEST);
 		}
 
+		if (!refreshTokenRepository.existsByRefreshToken(refreshToken)) {
+			log.info("Your Refresh Token NOT EXISTS");
+			return new ResponseEntity<>("Refresh Token is NOT EXISTS", HttpStatus.NOT_FOUND);
+		}
+
 		String username = jwtUtils.getUsername(refreshToken);
 		String role = jwtUtils.getRole(refreshToken);
 		String newAccessToken = jwtUtils.createJwt("Access", username, role, 60 * 60 * 200L);
+		String newRefreshToken = jwtUtils.createJwt("Refresh", username, role, 60 * 60 * 1000L * 24);
 		response.setHeader("Authorization", newAccessToken);
-		log.info("Reissue Completed : {}", newAccessToken);
+		response.addCookie(CookieUtils.createCookie("Refresh", newRefreshToken));
+		refreshTokenRepository.deleteByRefreshToken(refreshToken);
+		addRefreshToken(username, newAccessToken, newRefreshToken, 60 * 60 * 1000L * 24);
+		log.info("Reissue Completed : Refresh Rotating, Saving New Refresh");
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
+
+	private void addRefreshToken(String username, String accessToken, String refreshToken, Long expiredMs) {
+		RefreshToken refresh = new RefreshToken();
+		refresh.setUsername(username);
+		refresh.setAccessToken(accessToken);
+		refresh.setRefreshToken(refreshToken);
+		refresh.setExpiration(new Date(System.currentTimeMillis() + expiredMs).toString());
+		refreshTokenRepository.save(refresh);
+	}
 }
+

--- a/src/main/java/shop/nuribooks/auth/service/AuthService.java
+++ b/src/main/java/shop/nuribooks/auth/service/AuthService.java
@@ -1,0 +1,40 @@
+package shop.nuribooks.auth.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import shop.nuribooks.auth.common.util.CookieUtils;
+import shop.nuribooks.auth.common.util.JwtUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+	private final JwtUtils jwtUtils;
+
+	public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = CookieUtils.getValue(request, "Refresh");
+
+		if (refreshToken == null) {
+			log.info("Refresh Token is NULL");
+			return new ResponseEntity<>("Refresh Token is NULL", HttpStatus.BAD_REQUEST);
+		}
+
+		if (jwtUtils.isExpired(refreshToken)) {
+			log.info("Refresh Token is EXPIRED");
+			return new ResponseEntity<>("Refresh Token is Expired", HttpStatus.BAD_REQUEST);
+		}
+
+		String username = jwtUtils.getUsername(refreshToken);
+		String role = jwtUtils.getRole(refreshToken);
+		String newAccessToken = jwtUtils.createJwt("Access", username, role, 60 * 60 * 200L);
+		response.setHeader("Authorization", newAccessToken);
+		log.info("Reissue Completed : {}", newAccessToken);
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+}

--- a/src/main/java/shop/nuribooks/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/shop/nuribooks/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package shop.nuribooks.auth.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import shop.nuribooks.auth.common.feign.MemberFeignClient;
+import shop.nuribooks.auth.dto.CustomUserDetails;
+import shop.nuribooks.auth.dto.MemberResponse;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+	private final MemberFeignClient memberFeignClient;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		MemberResponse memberResponse = memberFeignClient.findByUsername(username).getBody();
+		if (memberResponse != null) {
+			return new CustomUserDetails(memberResponse);
+		}
+		throw new UsernameNotFoundException("회원 DB에 존재하지 않는 Username입니다.");
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,15 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://admin:1234@localhost:8761/eureka
+      #,http://admin:1234@localhost:8762/eureka
+  instance:
+    prefer-ip-address: true
 server:
   port: 8081
 jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: auth
+jwt:
+  secret-key: tmvmfldtlzbflxldhodlfjgrpdjfudnsrjdpdywlsWKrmfoehwoalTJdydxor
+  issuer: nuribooks-auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 server:
-  port: 8080
+  port: 8081
 jwt:
   secret-key: tmvmfldtlzbflxldhodlfjgrpdjfudnsrjdpdywlsWKrmfoehwoalTJdydxor
   issuer: nuribooks-auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,21 @@
 spring:
   application:
     name: auth
+  datasource:
+    url: jdbc:mysql://133.186.241.167:3306/project_be7_nuribooks_dev?useSSL=false&serverTimezone=UTC
+    username: be7_nuribooks
+    password: '@f3hgB7jc@KvWJQZ'
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+server:
+  port: 8080
 jwt:
   secret-key: tmvmfldtlzbflxldhodlfjgrpdjfudnsrjdpdywlsWKrmfoehwoalTJdydxor
   issuer: nuribooks-auth


### PR DESCRIPTION
## 작업 내용
- JWT를 활용한 기본 로그인/로그아웃 구현
  - 로그인 성공, 실패 시 ResponseEntity로 응답 전달
- 로그인 시 Header에 Access Token 발급, Cookie로 Refresh Token 발급
- Access Token 만료 시 Refresh Token을 활용한 재발급 처리
- 재발급 시 Refresh Rotate 적용
- Gateway 연동 확인
- Member API 사용을 위한 Feign Client 적용
 - Member DTO에 커스터마이징된 UserDetails, UserDetailsService 작성 예정
- DTO Record로 수정

## 작업 예정
- OAuth2 로그인
  - PAYCO 우선 적용 후 상황에 따라 Naver, Google 연동도 진행 계획
  - OAuth2 최초 요청 시 회원가입으로 안내
- 로그아웃 시 Token Blacklist 적용
- Refresh Token 저장소 MySQL에서 Redis로 Migration