### PR TITLE
fix: 재발행 시 쿠키 발급 시간 동기화 처리 및 토큰 만료시간에 Instant 적용

### DIFF
--- a/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/nuribooks/auth/common/filter/CustomLoginFilter.java
@@ -1,7 +1,7 @@
 package shop.nuribooks.auth.common.filter;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -82,7 +82,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		String refreshToken = jwtUtils.createJwt("Refresh", userId, role, JwtUtils.REFRESH_TOKEN_VALID_TIME);
 
 		response.setHeader("Authorization", "Bearer " + accessToken);
-		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken, CookieUtils.REFRESH_TOKEN_MAX_AGE));
+		response.addCookie(
+			CookieUtils.createCookie("Refresh", refreshToken, (int)(JwtUtils.REFRESH_TOKEN_VALID_TIME / 1000)));
 		addRefreshToken(userId, accessToken, refreshToken, JwtUtils.REFRESH_TOKEN_VALID_TIME);
 		log.info("로그인 성공 : ({}/enabled: {}), Refresh Token을 저장하였습니다.", userDetails.getUserId(),
 			userDetails.isEnabled());
@@ -113,7 +114,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 		refresh.setUsername(username);
 		refresh.setAccess(accessToken);
 		refresh.setRefresh(refreshToken);
-		refresh.setExpiration(new Date(System.currentTimeMillis() + expiredMs).toString());
+		refresh.setExpiration(Instant.now().plusMillis(expiredMs).toString());
 		refreshTokenRepository.save(refresh);
 	}
 }

--- a/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
+++ b/src/main/java/shop/nuribooks/auth/common/util/JwtUtils.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class JwtUtils {
-	public static final Long ACCESS_TOKEN_VALID_TIME = 60 * 60 * 100L;
+	public static final Long ACCESS_TOKEN_VALID_TIME = 60 * 60 * 250L;
 	public static final Long REFRESH_TOKEN_VALID_TIME = 60 * 60 * 1000L * 5;
 	private final SecretKey secretKey;
 	private final JwtProperties jwtProperties;

--- a/src/main/java/shop/nuribooks/auth/service/OAuth2UserService.java
+++ b/src/main/java/shop/nuribooks/auth/service/OAuth2UserService.java
@@ -1,7 +1,7 @@
 package shop.nuribooks.auth.service;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,7 +64,8 @@ public class OAuth2UserService {
 		String refreshToken = jwtUtils.createJwt("Refresh", userId, role, JwtUtils.REFRESH_TOKEN_VALID_TIME);
 
 		response.setHeader("Authorization", "Bearer " + accessToken);
-		response.addCookie(CookieUtils.createCookie("Refresh", refreshToken, CookieUtils.REFRESH_TOKEN_MAX_AGE));
+		response.addCookie(
+			CookieUtils.createCookie("Refresh", refreshToken, (int)(JwtUtils.REFRESH_TOKEN_VALID_TIME / 1000)));
 		addRefreshToken(userId, accessToken, refreshToken, JwtUtils.REFRESH_TOKEN_VALID_TIME);
 		memberFeignClient.informLogin(memberResponse.username());
 		log.info("로그인 성공! Refresh Token을 저장하였습니다.");
@@ -75,7 +76,7 @@ public class OAuth2UserService {
 		refresh.setUsername(username);
 		refresh.setAccess(accessToken);
 		refresh.setRefresh(refreshToken);
-		refresh.setExpiration(new Date(System.currentTimeMillis() + expiredMs).toString());
+		refresh.setExpiration(Instant.now().plusMillis(expiredMs).toString());
 		refreshTokenRepository.save(refresh);
 	}
 }

--- a/src/main/java/shop/nuribooks/auth/service/ReissueService.java
+++ b/src/main/java/shop/nuribooks/auth/service/ReissueService.java
@@ -1,10 +1,11 @@
 package shop.nuribooks.auth.service;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +24,9 @@ public class ReissueService {
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final JwtUtils jwtUtils;
 
+	@Transactional
 	public ResponseEntity<Void> reissue(String refreshToken, HttpServletResponse response) {
-		log.info("재발행을 위한 Refresh Token : {}", refreshToken);
+		log.info("Reissuing tokens for Refresh Token: {}", refreshToken);
 
 		if (refreshToken == null || refreshToken.isBlank()) {
 			log.info("Refresh Token is NULL");
@@ -37,34 +39,26 @@ public class ReissueService {
 		}
 
 		RefreshToken findRefresh = refreshTokenRepository.findByRefresh(refreshToken);
-
-		if (!refreshTokenRepository.existsByRefresh(refreshToken)) {
+		if (findRefresh == null) {
 			log.info("The Refresh Token does not Exist");
-			log.info("Find Refresh : {}", findRefresh);
 			throw new NotFoundException("Refresh Token is NOT EXISTS");
 		}
 
 		String username = jwtUtils.getUsername(refreshToken);
 		String role = jwtUtils.getRole(refreshToken);
+
 		String newAccessToken = jwtUtils.createJwt("Access", username, role, JwtUtils.ACCESS_TOKEN_VALID_TIME);
 		String newRefreshToken = jwtUtils.createJwt("Refresh", username, role, JwtUtils.REFRESH_TOKEN_VALID_TIME);
-		response.setHeader("Authorization", newAccessToken);
-		response.addCookie(CookieUtils.createCookie("Refresh", newRefreshToken, 60 * 60));
-		refreshTokenRepository.deleteByRefresh(refreshToken);
-		addRefreshToken(username, newAccessToken, newRefreshToken, 60 * 60 * 1000L * 24);
-		log.info("Reissue Completed : Refresh Rotating, Saving New Refresh");
-		log.info("새로 발급한 Access Token : {}", newAccessToken);
-		log.info("새로 발급한 Refresh Token : {}", newRefreshToken);
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
 
-	private void addRefreshToken(String username, String accessToken, String refreshToken, Long expiredMs) {
-		RefreshToken refresh = new RefreshToken();
-		refresh.setUsername(username);
-		refresh.setAccess(accessToken);
-		refresh.setRefresh(refreshToken);
-		refresh.setExpiration(new Date(System.currentTimeMillis() + expiredMs).toString());
-		refreshTokenRepository.save(refresh);
+		response.setHeader("Authorization", newAccessToken);
+		response.addCookie(
+			CookieUtils.createCookie("Refresh", newRefreshToken, (int)(JwtUtils.REFRESH_TOKEN_VALID_TIME / 1000)));
+
+		findRefresh.setAccess(newAccessToken);
+		findRefresh.setRefresh(newRefreshToken);
+		findRefresh.setExpiration(Instant.now().plusMillis(JwtUtils.REFRESH_TOKEN_VALID_TIME).toString());
+		log.info("Tokens reissued successfully: Access={}, Refresh={}", newAccessToken, newRefreshToken);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 }
 


### PR DESCRIPTION
- access token 유효시간 약 15분, refresh token 유효시간 5시간으로 설정
- 재발행 시 Refresh Token DB 업데이트
- 로그아웃 시 Refresh Token DB에서 삭제
- 재발행 시간 계산 시 Instant 타입 활용